### PR TITLE
Fix Windows, Linux & macOS compilation

### DIFF
--- a/codemp/client/FXExport.cpp
+++ b/codemp/client/FXExport.cpp
@@ -38,11 +38,11 @@ int	FX_RegisterEffect(const char *file)
 void FX_PlayEffect( const char *file, vec3_t org, vec3_t fwd, int vol, int rad )
 {
 #ifdef __FXCHECKER
-	if (_isnan(org[0]) || _isnan(org[1]) || _isnan(org[2]))
+	if (std::isnan(org[0]) || std::isnan(org[1]) || std::isnan(org[2]))
 	{
 		assert(0);
 	}
-	if (_isnan(fwd[0]) || _isnan(fwd[1]) || _isnan(fwd[2]))
+	if (std::isnan(fwd[0]) || std::isnan(fwd[1]) || std::isnan(fwd[2]))
 	{
 		assert(0);
 	}
@@ -59,11 +59,11 @@ void FX_PlayEffect( const char *file, vec3_t org, vec3_t fwd, int vol, int rad )
 void FX_PlayEffectID( int id, vec3_t org, vec3_t fwd, int vol, int rad, bool isPortal )
 {
 #ifdef __FXCHECKER
-	if (_isnan(org[0]) || _isnan(org[1]) || _isnan(org[2]))
+	if (std::isnan(org[0]) || std::isnan(org[1]) || std::isnan(org[2]))
 	{
 		assert(0);
 	}
-	if (_isnan(fwd[0]) || _isnan(fwd[1]) || _isnan(fwd[2]))
+	if (std::isnan(fwd[0]) || std::isnan(fwd[1]) || std::isnan(fwd[2]))
 	{
 		assert(0);
 	}
@@ -86,7 +86,7 @@ void FX_PlayEntityEffectID( int id, vec3_t org,
 						matrix3_t axis, const int boltInfo, const int entNum, int vol, int rad )
 {
 #ifdef __FXCHECKER
-	if (_isnan(org[0]) || _isnan(org[1]) || _isnan(org[2]))
+	if (std::isnan(org[0]) || std::isnan(org[1]) || std::isnan(org[2]))
 	{
 		assert(0);
 	}

--- a/codemp/client/snd_dma.cpp
+++ b/codemp/client/snd_dma.cpp
@@ -842,7 +842,7 @@ void EALFileInit(const char *level)
 			long lRoom = -10000;
 			for (int i = 0; i < s_NumFXSlots; i++)
 			{
-				s_eaxSet(&s_FXSlotInfo[i].FXSlotGuid, EAXREVERB_ROOM, nullptr,
+				s_eaxSet(&s_FXSlotInfo[i].FXSlotGuid, EAXREVERB_ROOM, 0,
 					&lRoom, sizeof(long));
 			}
 		}
@@ -1406,7 +1406,7 @@ void S_StartSound(const vec3_t origin, int entityNum, int entchannel, sfxHandle_
 				{
 					// Stop this sound
 					alSourceStop(ch->alSource);
-					alSourcei(ch->alSource, AL_BUFFER, nullptr);
+					alSourcei(ch->alSource, AL_BUFFER, 0);
 					ch->bPlaying = false;
 					ch->thesfx = nullptr;
 					break;
@@ -1422,7 +1422,7 @@ void S_StartSound(const vec3_t origin, int entityNum, int entchannel, sfxHandle_
 				{
 					// Stop this sound
 					alSourceStop(ch->alSource);
-					alSourcei(ch->alSource, AL_BUFFER, nullptr);
+					alSourcei(ch->alSource, AL_BUFFER, 0);
 					ch->bPlaying = false;
 					ch->thesfx = nullptr;
 					break;
@@ -1611,7 +1611,7 @@ void S_StopSounds(void)
 		for (i = 0; i < s_numChannels; i++, ch++)
 		{
 			alSourceStop(s_channels[i].alSource);
-			alSourcei(s_channels[i].alSource, AL_BUFFER, nullptr);
+			alSourcei(s_channels[i].alSource, AL_BUFFER, 0);
 			ch->thesfx = nullptr;
 			memset(&ch->MP3StreamHeader, 0, sizeof(MP3STREAM));
 			ch->bLooping = false;
@@ -2269,10 +2269,10 @@ void S_Respatialize( int entityNum, const vec3_t head, matrix3_t axis, int inwat
 					// Load underwater reverb effect into FX Slot 0, and set this as the Primary FX Slot
 					unsigned int ulEnvironment = EAX_ENVIRONMENT_UNDERWATER;
 					s_eaxSet(&EAXPROPERTYID_EAX40_FXSlot0, EAXREVERB_ENVIRONMENT,
-						nullptr, &ulEnvironment, sizeof(unsigned int));
+						0, &ulEnvironment, sizeof(unsigned int));
 					s_EnvironmentID = 999;
 
-					s_eaxSet(&EAXPROPERTYID_EAX40_Context, EAXCONTEXT_PRIMARYFXSLOTID, nullptr, (ALvoid*)&EAXPROPERTYID_EAX40_FXSlot0,
+					s_eaxSet(&EAXPROPERTYID_EAX40_Context, EAXCONTEXT_PRIMARYFXSLOTID, 0, (ALvoid*)&EAXPROPERTYID_EAX40_FXSlot0,
 						sizeof(GUID));
 
 					// Occlude all sounds into this environment, and mute all their sends to other reverbs
@@ -2697,7 +2697,7 @@ void S_Update_(void) {
 					nBuffersToAdd = i + 1;
 
 				// Make sure queue is empty first
-				alSourcei(s_channels[source].alSource, AL_BUFFER, nullptr);
+				alSourcei(s_channels[source].alSource, AL_BUFFER, 0);
 
 				for (i = 0; i < nBuffersToAdd; i++)
 				{
@@ -2867,7 +2867,7 @@ void UpdateSingleShotSounds()
 						if (state == AL_STOPPED)
 						{
 							// Attach nullptr buffer to Source to remove any buffers left in the queue
-							alSourcei(ch->alSource, AL_BUFFER, nullptr);
+							alSourcei(ch->alSource, AL_BUFFER, 0);
 							ch->thesfx = nullptr;
 							ch->bPlaying = false;
 						}
@@ -4962,7 +4962,7 @@ void InitEAXManager()
 
 					for (i = 0; i < EAX_MAX_FXSLOTS; i++)
 					{
-						if (s_eaxSet(&FXSlotGuids[i], EAXFXSLOT_ALLPARAMETERS, nullptr, &FXSlotProp, sizeof(EAXFXSLOTPROPERTIES))==AL_NO_ERROR)
+						if (s_eaxSet(&FXSlotGuids[i], EAXFXSLOT_ALLPARAMETERS, 0, &FXSlotProp, sizeof(EAXFXSLOTPROPERTIES))==AL_NO_ERROR)
 						{
 							// We can use this slot
 							s_FXSlotInfo[s_NumFXSlots].FXSlotGuid = FXSlotGuids[i];
@@ -4972,13 +4972,13 @@ void InitEAXManager()
 						{
 							// If this slot already contains a reverb, then we will use it anyway (Slot 0 will
 							// be in this category).  (It probably means that Slot 0 is locked)
-							if (s_eaxGet(&FXSlotGuids[i], EAXFXSLOT_LOADEFFECT, nullptr, &Effect, sizeof(GUID))==AL_NO_ERROR)
+							if (s_eaxGet(&FXSlotGuids[i], EAXFXSLOT_LOADEFFECT, 0, &Effect, sizeof(GUID))==AL_NO_ERROR)
 							{
 								if (Effect == EAX_REVERB_EFFECT)
 								{
 									// We can use this slot
 									// Make sure the environment flag is on
-									s_eaxSet(&FXSlotGuids[i], EAXFXSLOT_FLAGS, nullptr, &FXSlotProp.ulFlags, sizeof(unsigned long));
+									s_eaxSet(&FXSlotGuids[i], EAXFXSLOT_FLAGS, 0, &FXSlotProp.ulFlags, sizeof(unsigned long));
 									s_FXSlotInfo[s_NumFXSlots].FXSlotGuid = FXSlotGuids[i];
 									s_NumFXSlots++;
 								}
@@ -5385,7 +5385,7 @@ void UpdateEAXListener()
 
 						// Set Environment
 						s_eaxSet(&EAXPROPERTYID_EAX40_FXSlot0, EAXREVERB_ALLPARAMETERS,
-							nullptr, &s_eaxLPCur, sizeof(EAXREVERBPROPERTIES));
+							0, &s_eaxLPCur, sizeof(EAXREVERBPROPERTIES));
 
 						s_EnvironmentID = lID;
 					}
@@ -5497,7 +5497,7 @@ void UpdateEAXListener()
 
 				// Mute it
 				lVolume = -10000;
-				if (s_eaxSet(&s_FXSlotInfo[i].FXSlotGuid, EAXFXSLOT_VOLUME, nullptr, &lVolume, sizeof(long))!=AL_NO_ERROR)
+				if (s_eaxSet(&s_FXSlotInfo[i].FXSlotGuid, EAXFXSLOT_VOLUME, 0, &lVolume, sizeof(long))!=AL_NO_ERROR)
 					Com_OPrintf("Failed to Mute FX Slot\n");
 
 				// If any source is sending to this Slot ID then we need to stop them sending to the slot
@@ -5555,7 +5555,7 @@ void UpdateEAXListener()
 							// Override Air Absorption HF
 							Reverb.flAirAbsorptionHF = 0.0f;
 
-							s_eaxSet(&s_FXSlotInfo[i].FXSlotGuid, EAXREVERB_ALLPARAMETERS, nullptr, &Reverb, sizeof(EAXREVERBPROPERTIES));
+							s_eaxSet(&s_FXSlotInfo[i].FXSlotGuid, EAXREVERB_ALLPARAMETERS, 0, &Reverb, sizeof(EAXREVERBPROPERTIES));
 
 							// See if any Sources are in this environment, if they are, enable their sends
 							ch = s_channels + 1;
@@ -5620,7 +5620,7 @@ void UpdateEAXListener()
 		// Make sure Primary FX Slot ID is set correctly
 		if (s_EnvironmentID != ReverbData[2].lEnvID)
 		{
-			s_eaxSet(&EAXPROPERTYID_EAX40_Context, EAXCONTEXT_PRIMARYFXSLOTID, nullptr, &(s_FXSlotInfo[s_lpEnvTable[ReverbData[2].lEnvID].lFXSlotID].FXSlotGuid), sizeof(GUID));
+			s_eaxSet(&EAXPROPERTYID_EAX40_Context, EAXCONTEXT_PRIMARYFXSLOTID, 0, &(s_FXSlotInfo[s_lpEnvTable[ReverbData[2].lEnvID].lFXSlotID].FXSlotGuid), sizeof(GUID));
 			s_EnvironmentID = ReverbData[2].lEnvID;
 		}
 
@@ -5708,10 +5708,10 @@ void UpdateEAXListener()
 				Pan.y *= -flMagnitude;
 				Pan.z *= -flMagnitude;
 
-				if (s_eaxSet(&s_FXSlotInfo[i].FXSlotGuid, EAXREVERB_REVERBPAN, nullptr, &Pan, sizeof(EAXVECTOR))!=AL_NO_ERROR)
+				if (s_eaxSet(&s_FXSlotInfo[i].FXSlotGuid, EAXREVERB_REVERBPAN, 0, &Pan, sizeof(EAXVECTOR))!=AL_NO_ERROR)
 					Com_OPrintf("Failed to set Listener Reverb Pan\n");
 
-				if (s_eaxSet(&s_FXSlotInfo[i].FXSlotGuid, EAXREVERB_REFLECTIONSPAN, nullptr, &Pan, sizeof(EAXVECTOR))!=AL_NO_ERROR)
+				if (s_eaxSet(&s_FXSlotInfo[i].FXSlotGuid, EAXREVERB_REFLECTIONSPAN, 0, &Pan, sizeof(EAXVECTOR))!=AL_NO_ERROR)
 					Com_OPrintf("Failed to set Listener Reflections Pan\n");
 			}
 			else
@@ -5758,10 +5758,10 @@ void UpdateEAXListener()
 				Pan.y *= flMagnitude;
 				Pan.z *= flMagnitude;
 
-				if (s_eaxSet(&s_FXSlotInfo[i].FXSlotGuid, EAXREVERB_REVERBPAN, nullptr, &Pan, sizeof(EAXVECTOR))!=AL_NO_ERROR)
+				if (s_eaxSet(&s_FXSlotInfo[i].FXSlotGuid, EAXREVERB_REVERBPAN, 0, &Pan, sizeof(EAXVECTOR))!=AL_NO_ERROR)
 					Com_OPrintf("Failed to set Reverb Pan\n");
 
-				if (s_eaxSet(&s_FXSlotInfo[i].FXSlotGuid, EAXREVERB_REFLECTIONSPAN, nullptr, &Pan, sizeof(EAXVECTOR))!=AL_NO_ERROR)
+				if (s_eaxSet(&s_FXSlotInfo[i].FXSlotGuid, EAXREVERB_REFLECTIONSPAN, 0, &Pan, sizeof(EAXVECTOR))!=AL_NO_ERROR)
 					Com_OPrintf("Failed to set Reflections Pan\n");
 			}
 		}
@@ -5769,7 +5769,7 @@ void UpdateEAXListener()
 		lVolume = 0;
 		for (i = 0; i < s_NumFXSlots; i++)
 		{
-			if (s_eaxSet(&s_FXSlotInfo[i].FXSlotGuid, EAXFXSLOT_VOLUME, nullptr, &lVolume, sizeof(long))!=AL_NO_ERROR)
+			if (s_eaxSet(&s_FXSlotInfo[i].FXSlotGuid, EAXFXSLOT_VOLUME, 0, &lVolume, sizeof(long))!=AL_NO_ERROR)
 				Com_OPrintf("Failed to set FX Slot Volume to 0\n");
 		}
 	}

--- a/codemp/game/g_local.h
+++ b/codemp/game/g_local.h
@@ -44,10 +44,6 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 // DEFINE
 // ======================================================================
 
-#ifndef FINAL_BUILD
-#define DEBUG_SABER_BOX
-#endif
-
 // macros
 #define FOFS(x) offsetof(gentity_t, x)
 

--- a/codemp/game/g_xcvar.h
+++ b/codemp/game/g_xcvar.h
@@ -26,6 +26,10 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 // DEFINE
 // ======================================================================
 
+#ifndef FINAL_BUILD
+	#define DEBUG_SABER_BOX
+#endif
+
 #ifdef XCVAR_PROTO
 	#define XCVAR_DEF( name, defVal, update, flags, announce ) extern vmCvar_t name;
 #endif

--- a/codemp/rd-dedicated/G2_API.cpp
+++ b/codemp/rd-dedicated/G2_API.cpp
@@ -1766,7 +1766,7 @@ bool G2API_GetBoltMatrix(CGhoul2Info_v &ghoul2, const int modelIndex, const int 
 				{
 					for ( int j = 0; j < 4; j++ )
 					{
-						assert( !_isnan(matrix->matrix[i][j]));
+						assert( !std::isnan(matrix->matrix[i][j]));
 					}
 				}
 #endif// _DEBUG

--- a/codemp/rd-dedicated/G2_bones.cpp
+++ b/codemp/rd-dedicated/G2_bones.cpp
@@ -1237,7 +1237,7 @@ static void G2_Generate_MatrixRag(
 	{
 		for (j = 0; j < 4; j++ )
 		{
-			assert( !Q_isnan(bone.matrix.matrix[i][j]));
+			assert( !std::isnan(bone.matrix.matrix[i][j]));
 		}
 	}
 #endif// _DEBUG
@@ -1316,8 +1316,8 @@ static int G2_Set_Bone_Rag(const mdxaHeader_t *mod_a,
 
 		G2_GetBoneMatrixLow(ghoul2,bone.boneNumber,scale,bone.originalTrueBoneMatrix,bone.basepose,bone.baseposeInv);
 //		bone.parentRawBoneIndex=G2_GetParentBoneMatrixLow(ghoul2,bone.boneNumber,scale,bone.parentTrueBoneMatrix,bone.baseposeParent,bone.baseposeInvParent);
-		assert( !Q_isnan(bone.originalTrueBoneMatrix.matrix[1][1]));
-		assert( !Q_isnan(bone.originalTrueBoneMatrix.matrix[1][3]));
+		assert( !std::isnan(bone.originalTrueBoneMatrix.matrix[1][1]));
+		assert( !std::isnan(bone.originalTrueBoneMatrix.matrix[1][3]));
 		bone.originalOrigin[0]=bone.originalTrueBoneMatrix.matrix[0][3];
 		bone.originalOrigin[1]=bone.originalTrueBoneMatrix.matrix[1][3];
 		bone.originalOrigin[2]=bone.originalTrueBoneMatrix.matrix[2][3];
@@ -1852,7 +1852,7 @@ void G2_SetRagDollBullet(CGhoul2Info &ghoul2,const vec3_t rayStart,const vec3_t 
 //					bone.velocityEffector[0]=shotDir[0]*(effect+flrand(0.0f,0.05f))*flrand(-0.1f,3.0f);
 //					bone.velocityEffector[1]=shotDir[1]*(effect+flrand(0.0f,0.05f))*flrand(-0.1f,3.0f);
 //					bone.velocityEffector[2]=fabs(shotDir[2])*(effect+flrand(0.0f,0.05f))*flrand(-0.1f,3.0f);
-					assert( !Q_isnan(shotDir[2]));
+					assert( !std::isnan(shotDir[2]));
 	//				bone.currentAngles[0]+=flrand(-10.0f*lenr,10.0f*lenr);
 	//				bone.currentAngles[1]+=flrand(-10.0f*lenr,10.0f*lenr);
 	//				bone.currentAngles[2]+=flrand(-10.0f*lenr,10.0f*lenr);
@@ -2240,7 +2240,7 @@ static void G2_RagDollCurrentPosition(CGhoul2Info_v &ghoul2V,int g2Index,int fra
 		for (k=0;k<3;k++)
 		{
 			ragEffectors[i].currentOrigin[k]=ragBones[i].matrix[k][3];
-			assert( !Q_isnan(ragEffectors[i].currentOrigin[k]));
+			assert( !std::isnan(ragEffectors[i].currentOrigin[k]));
 			if (!i)
 			{
 				// set mins, maxs and cm
@@ -2510,10 +2510,10 @@ static bool G2_RagDollSettlePositionNumeroTrois(CGhoul2Info_v &ghoul2V, const ve
 
 		{
 			trace_t		tr;
-			assert( !Q_isnan(testStart[1]));
-			assert( !Q_isnan(testEnd[1]));
-			assert( !Q_isnan(testMins[1]));
-			assert( !Q_isnan(testMaxs[1]));
+			assert( !std::isnan(testStart[1]));
+			assert( !std::isnan(testEnd[1]));
+			assert( !std::isnan(testMins[1]));
+			assert( !std::isnan(testMaxs[1]));
 			Rag_Trace(&tr,testStart,testMins,testMaxs,testEnd,ignoreNum,RAG_MASK,G2_NOCOLLIDE,0/*SV_TRACE_NO_PLAYER*/);
 			if (tr.entityNum==0)
 			{
@@ -2568,10 +2568,10 @@ static bool G2_RagDollSettlePositionNumeroTrois(CGhoul2Info_v &ghoul2V, const ve
 		vec3_t testEnd;
 		VectorCopy(testStart,testEnd); //last arg is dest
 		testEnd[2]-=8.0f;
-		assert( !Q_isnan(testStart[1]));
-		assert( !Q_isnan(testEnd[1]));
-		assert( !Q_isnan(testMins[1]));
-		assert( !Q_isnan(testMaxs[1]));
+		assert( !std::isnan(testStart[1]));
+		assert( !std::isnan(testEnd[1]));
+		assert( !std::isnan(testMins[1]));
+		assert( !std::isnan(testMaxs[1]));
 		float vertEffectorTraceFraction=0.0f;
 		{
 			trace_t		tr;
@@ -2647,10 +2647,10 @@ static bool G2_RagDollSettlePositionNumeroTrois(CGhoul2Info_v &ghoul2V, const ve
 			VectorCopy(effectorGroundSpot,testEnd); //last arg is dest
 			bone.solidCount = 0;
 		}
-		assert( !Q_isnan(testStart[1]));
-		assert( !Q_isnan(testEnd[1]));
-		assert( !Q_isnan(testMins[1]));
-		assert( !Q_isnan(testMaxs[1]));
+		assert( !std::isnan(testStart[1]));
+		assert( !std::isnan(testEnd[1]));
+		assert( !std::isnan(testMins[1]));
+		assert( !std::isnan(testMaxs[1]));
 
 		float ztest;
 
@@ -2828,7 +2828,7 @@ static inline void G2_RagGetWorldAnimMatrix(CGhoul2Info &ghoul2, boneInfo_t &bon
 	//bone matrix and give us a useable world position
 	Multiply_3x4Matrix(&retMatrix, &worldMatrix, &baseBoneMatrix);
 
-	assert(!Q_isnan(retMatrix.matrix[2][3]));
+	assert(!std::isnan(retMatrix.matrix[2][3]));
 }
 
 //get the current pelvis Z direction and the base anim matrix Z direction
@@ -3392,7 +3392,7 @@ static void G2_RagDollSolve(CGhoul2Info_v &ghoul2V,int g2Index,float decay,int f
 			{
 				float	magicFactor12=0.25f; // dampfactor for pelvis pos
 				float	magicFactor13=0.20f; //controls the speed of the gradient descent (pelvis pos)
-				assert( !Q_isnan(bone.ragOverrideMatrix.matrix[2][3]));
+				assert( !std::isnan(bone.ragOverrideMatrix.matrix[2][3]));
 				vec3_t deltaInEntitySpace;
 				TransformPoint(desiredPelvisOffset,deltaInEntitySpace,&N); // dest middle arg
 				for (k=0;k<3;k++)
@@ -3461,10 +3461,10 @@ static void G2_RagDollSolve(CGhoul2Info_v &ghoul2V,int g2Index,float decay,int f
 						vec3_t change;
 						VectorSubtract(tPosition,ragEffectors[depIndex].currentOrigin,change); // dest is last arg
 						float goodness=DotProduct(change,ragEffectors[depIndex].desiredDirection);
-						assert( !Q_isnan(goodness));
+						assert( !std::isnan(goodness));
 						goodness*=depBone.weight;
 						delAngles[k]+=goodness; // keep bigger stuff more out of wall or something
-						assert( !Q_isnan(delAngles[k]));
+						assert( !std::isnan(delAngles[k]));
 					}
 					allSolidCount += depBone.solidCount;
 				}
@@ -3559,7 +3559,7 @@ static void G2_RagDollSolve(CGhoul2Info_v &ghoul2V,int g2Index,float decay,int f
 			Create_Matrix(bone.currentAngles,&temp1);
 			Multiply_3x4Matrix(&temp2,&temp1,bone.baseposeInv);
 			Multiply_3x4Matrix(&bone.ragOverrideMatrix,bone.basepose, &temp2);
-			assert( !Q_isnan(bone.ragOverrideMatrix.matrix[2][3]));
+			assert( !std::isnan(bone.ragOverrideMatrix.matrix[2][3]));
 		}
 		G2_Generate_MatrixRag(blist,ragBlistIndex[bone.boneNumber]);
 	}
@@ -3694,10 +3694,10 @@ static void G2_IKSolve(CGhoul2Info_v &ghoul2V,int g2Index,float decay,int frameN
 					vec3_t change;
 					VectorSubtract(tPosition,ragEffectors[depIndex].currentOrigin,change); // dest is last arg
 					float goodness=DotProduct(change,ragEffectors[depIndex].desiredDirection);
-					assert( !Q_isnan(goodness));
+					assert( !std::isnan(goodness));
 					goodness*=depBone.weight;
 					delAngles[k]+=goodness; // keep bigger stuff more out of wall or something
-					assert( !Q_isnan(delAngles[k]));
+					assert( !std::isnan(delAngles[k]));
 				}
 			}
 		}
@@ -3753,7 +3753,7 @@ static void G2_IKSolve(CGhoul2Info_v &ghoul2V,int g2Index,float decay,int frameN
 		Create_Matrix(bone.currentAngles, &temp1);
 		Multiply_3x4Matrix(&temp2, &temp1, bone.baseposeInv);
 		Multiply_3x4Matrix(&bone.ragOverrideMatrix, bone.basepose, &temp2);
-		assert( !Q_isnan(bone.ragOverrideMatrix.matrix[2][3]));
+		assert( !std::isnan(bone.ragOverrideMatrix.matrix[2][3]));
 
 		G2_Generate_MatrixRag(blist, ragBlistIndex[bone.boneNumber]);
 	}

--- a/codemp/rd-dedicated/tr_ghoul2.cpp
+++ b/codemp/rd-dedicated/tr_ghoul2.cpp
@@ -242,7 +242,7 @@ class CBoneCache
 		{
 			for ( int j = 0; j < 4; j++ )
 			{
-				assert( !Q_isnan(mSmoothBones[index].boneMatrix.matrix[i][j]));
+				assert( !std::isnan(mSmoothBones[index].boneMatrix.matrix[i][j]));
 			}
 		}
 #endif// _DEBUG
@@ -632,7 +632,7 @@ void G2_GetBoneMatrixLow(CGhoul2Info &ghoul2,int boneNum,const vec3_t scale,mdxa
 	{
 		for ( int j = 0; j < 4; j++ )
 		{
-			assert( !Q_isnan(retMatrix.matrix[i][j]));
+			assert( !std::isnan(retMatrix.matrix[i][j]));
 		}
 	}
 #endif// _DEBUG

--- a/codemp/rd-vanilla/G2_API.cpp
+++ b/codemp/rd-vanilla/G2_API.cpp
@@ -1991,7 +1991,7 @@ bool G2API_GetBoltMatrix(CGhoul2Info_v &ghoul2, const int modelIndex, const int 
 				{
 					for ( int j = 0; j < 4; j++ )
 					{
-						assert( !_isnan(matrix->matrix[i][j]));
+						assert( !std::isnan(matrix->matrix[i][j]));
 					}
 				}
 #endif// _DEBUG

--- a/codemp/rd-vanilla/G2_bones.cpp
+++ b/codemp/rd-vanilla/G2_bones.cpp
@@ -1240,7 +1240,7 @@ static void G2_Generate_MatrixRag(
 	{
 		for (j = 0; j < 4; j++ )
 		{
-			assert( !Q_isnan(bone.matrix.matrix[i][j]));
+			assert( !std::isnan(bone.matrix.matrix[i][j]));
 		}
 	}
 #endif// _DEBUG
@@ -1319,8 +1319,8 @@ static int G2_Set_Bone_Rag(const mdxaHeader_t *mod_a,
 
 		G2_GetBoneMatrixLow(ghoul2,bone.boneNumber,scale,bone.originalTrueBoneMatrix,bone.basepose,bone.baseposeInv);
 //		bone.parentRawBoneIndex=G2_GetParentBoneMatrixLow(ghoul2,bone.boneNumber,scale,bone.parentTrueBoneMatrix,bone.baseposeParent,bone.baseposeInvParent);
-		assert( !Q_isnan(bone.originalTrueBoneMatrix.matrix[1][1]));
-		assert( !Q_isnan(bone.originalTrueBoneMatrix.matrix[1][3]));
+		assert( !std::isnan(bone.originalTrueBoneMatrix.matrix[1][1]));
+		assert( !std::isnan(bone.originalTrueBoneMatrix.matrix[1][3]));
 		bone.originalOrigin[0]=bone.originalTrueBoneMatrix.matrix[0][3];
 		bone.originalOrigin[1]=bone.originalTrueBoneMatrix.matrix[1][3];
 		bone.originalOrigin[2]=bone.originalTrueBoneMatrix.matrix[2][3];
@@ -1677,7 +1677,7 @@ void G2_SetRagDoll(CGhoul2Info_v &ghoul2V,CRagDollParams *parms)
 						//I am just leaving it whatever it is for now, because my velocity scaling
 						//only works on x and y and the gravity stuff for NPCs is a bit unpleasent
 						//trying to change/work with
-						assert( !Q_isnan(bone.lastShotDir[1]));
+						assert( !std::isnan(bone.lastShotDir[1]));
 						*/
 					}
 				}
@@ -1974,7 +1974,7 @@ void G2_SetRagDollBullet(CGhoul2Info &ghoul2,const vec3_t rayStart,const vec3_t 
 //					bone.velocityEffector[0]=shotDir[0]*(effect+flrand(0.0f,0.05f))*flrand(-0.1f,3.0f);
 //					bone.velocityEffector[1]=shotDir[1]*(effect+flrand(0.0f,0.05f))*flrand(-0.1f,3.0f);
 //					bone.velocityEffector[2]=fabs(shotDir[2])*(effect+flrand(0.0f,0.05f))*flrand(-0.1f,3.0f);
-					assert( !Q_isnan(shotDir[2]));
+					assert( !std::isnan(shotDir[2]));
 	//				bone.currentAngles[0]+=flrand(-10.0f*lenr,10.0f*lenr);
 	//				bone.currentAngles[1]+=flrand(-10.0f*lenr,10.0f*lenr);
 	//				bone.currentAngles[2]+=flrand(-10.0f*lenr,10.0f*lenr);
@@ -2362,7 +2362,7 @@ static void G2_RagDollCurrentPosition(CGhoul2Info_v &ghoul2V,int g2Index,int fra
 		for (k=0;k<3;k++)
 		{
 			ragEffectors[i].currentOrigin[k]=ragBones[i].matrix[k][3];
-			assert( !Q_isnan(ragEffectors[i].currentOrigin[k]));
+			assert( !std::isnan(ragEffectors[i].currentOrigin[k]));
 			if (!i)
 			{
 				// set mins, maxs and cm
@@ -2668,10 +2668,10 @@ static bool G2_RagDollSettlePositionNumeroTrois(CGhoul2Info_v &ghoul2V, const ve
 
 		{
 			trace_t		tr;
-			assert( !Q_isnan(testStart[1]));
-			assert( !Q_isnan(testEnd[1]));
-			assert( !Q_isnan(testMins[1]));
-			assert( !Q_isnan(testMaxs[1]));
+			assert( !std::isnan(testStart[1]));
+			assert( !std::isnan(testEnd[1]));
+			assert( !std::isnan(testMins[1]));
+			assert( !std::isnan(testMaxs[1]));
 			Rag_Trace(&tr,testStart,testMins,testMaxs,testEnd,ignoreNum,RAG_MASK,G2_NOCOLLIDE,0/*SV_TRACE_NO_PLAYER*/);
 			if (tr.entityNum==0)
 			{
@@ -2726,10 +2726,10 @@ static bool G2_RagDollSettlePositionNumeroTrois(CGhoul2Info_v &ghoul2V, const ve
 		vec3_t testEnd;
 		VectorCopy(testStart,testEnd); //last arg is dest
 		testEnd[2]-=8.0f;
-		assert( !Q_isnan(testStart[1]));
-		assert( !Q_isnan(testEnd[1]));
-		assert( !Q_isnan(testMins[1]));
-		assert( !Q_isnan(testMaxs[1]));
+		assert( !std::isnan(testStart[1]));
+		assert( !std::isnan(testEnd[1]));
+		assert( !std::isnan(testMins[1]));
+		assert( !std::isnan(testMaxs[1]));
 		float vertEffectorTraceFraction=0.0f;
 		{
 			trace_t		tr;
@@ -2825,10 +2825,10 @@ static bool G2_RagDollSettlePositionNumeroTrois(CGhoul2Info_v &ghoul2V, const ve
 			VectorCopy(effectorGroundSpot,testEnd); //last arg is dest
 			bone.solidCount = 0;
 		}
-		assert( !Q_isnan(testStart[1]));
-		assert( !Q_isnan(testEnd[1]));
-		assert( !Q_isnan(testMins[1]));
-		assert( !Q_isnan(testMaxs[1]));
+		assert( !std::isnan(testStart[1]));
+		assert( !std::isnan(testEnd[1]));
+		assert( !std::isnan(testMins[1]));
+		assert( !std::isnan(testMaxs[1]));
 
 		float ztest;
 
@@ -3026,7 +3026,7 @@ static inline void G2_RagGetWorldAnimMatrix(CGhoul2Info &ghoul2, boneInfo_t &bon
 	//bone matrix and give us a useable world position
 	Multiply_3x4Matrix(&retMatrix, &worldMatrix, &baseBoneMatrix);
 
-	assert(!Q_isnan(retMatrix.matrix[2][3]));
+	assert(!std::isnan(retMatrix.matrix[2][3]));
 }
 
 //get the current pelvis Z direction and the base anim matrix Z direction
@@ -3601,7 +3601,7 @@ static void G2_RagDollSolve(CGhoul2Info_v &ghoul2V,int g2Index,float decay,int f
 			{
 				float	magicFactor12=0.25f; // dampfactor for pelvis pos
 				float	magicFactor13=0.20f; //controls the speed of the gradient descent (pelvis pos)
-				assert( !Q_isnan(bone.ragOverrideMatrix.matrix[2][3]));
+				assert( !std::isnan(bone.ragOverrideMatrix.matrix[2][3]));
 				vec3_t deltaInEntitySpace;
 				TransformPoint(desiredPelvisOffset,deltaInEntitySpace,&N); // dest middle arg
 				for (k=0;k<3;k++)
@@ -3670,10 +3670,10 @@ static void G2_RagDollSolve(CGhoul2Info_v &ghoul2V,int g2Index,float decay,int f
 						vec3_t change;
 						VectorSubtract(tPosition,ragEffectors[depIndex].currentOrigin,change); // dest is last arg
 						float goodness=DotProduct(change,ragEffectors[depIndex].desiredDirection);
-						assert( !Q_isnan(goodness));
+						assert( !std::isnan(goodness));
 						goodness*=depBone.weight;
 						delAngles[k]+=goodness; // keep bigger stuff more out of wall or something
-						assert( !Q_isnan(delAngles[k]));
+						assert( !std::isnan(delAngles[k]));
 					}
 					allSolidCount += depBone.solidCount;
 				}
@@ -3768,7 +3768,7 @@ static void G2_RagDollSolve(CGhoul2Info_v &ghoul2V,int g2Index,float decay,int f
 			Create_Matrix(bone.currentAngles,&temp1);
 			Multiply_3x4Matrix(&temp2,&temp1,bone.baseposeInv);
 			Multiply_3x4Matrix(&bone.ragOverrideMatrix,bone.basepose, &temp2);
-			assert( !Q_isnan(bone.ragOverrideMatrix.matrix[2][3]));
+			assert( !std::isnan(bone.ragOverrideMatrix.matrix[2][3]));
 		}
 		G2_Generate_MatrixRag(blist,ragBlistIndex[bone.boneNumber]);
 	}
@@ -3903,10 +3903,10 @@ static void G2_IKSolve(CGhoul2Info_v &ghoul2V,int g2Index,float decay,int frameN
 					vec3_t change;
 					VectorSubtract(tPosition,ragEffectors[depIndex].currentOrigin,change); // dest is last arg
 					float goodness=DotProduct(change,ragEffectors[depIndex].desiredDirection);
-					assert( !Q_isnan(goodness));
+					assert( !std::isnan(goodness));
 					goodness*=depBone.weight;
 					delAngles[k]+=goodness; // keep bigger stuff more out of wall or something
-					assert( !Q_isnan(delAngles[k]));
+					assert( !std::isnan(delAngles[k]));
 				}
 			}
 		}
@@ -3962,7 +3962,7 @@ static void G2_IKSolve(CGhoul2Info_v &ghoul2V,int g2Index,float decay,int frameN
 		Create_Matrix(bone.currentAngles, &temp1);
 		Multiply_3x4Matrix(&temp2, &temp1, bone.baseposeInv);
 		Multiply_3x4Matrix(&bone.ragOverrideMatrix, bone.basepose, &temp2);
-		assert( !Q_isnan(bone.ragOverrideMatrix.matrix[2][3]));
+		assert( !std::isnan(bone.ragOverrideMatrix.matrix[2][3]));
 
 		G2_Generate_MatrixRag(blist, ragBlistIndex[bone.boneNumber]);
 	}

--- a/codemp/rd-vanilla/tr_ghoul2.cpp
+++ b/codemp/rd-vanilla/tr_ghoul2.cpp
@@ -242,7 +242,7 @@ class CBoneCache
 		{
 			for ( int j = 0; j < 4; j++ )
 			{
-				assert( !Q_isnan(mSmoothBones[index].boneMatrix.matrix[i][j]));
+				assert( !std::isnan(mSmoothBones[index].boneMatrix.matrix[i][j]));
 			}
 		}
 #endif// _DEBUG
@@ -632,7 +632,7 @@ void G2_GetBoneMatrixLow(CGhoul2Info &ghoul2,int boneNum,const vec3_t scale,mdxa
 	{
 		for ( int j = 0; j < 4; j++ )
 		{
-			assert( !Q_isnan(retMatrix.matrix[i][j]));
+			assert( !std::isnan(retMatrix.matrix[i][j]));
 		}
 	}
 #endif// _DEBUG

--- a/codemp/rd-vanilla/tr_scene.cpp
+++ b/codemp/rd-vanilla/tr_scene.cpp
@@ -180,7 +180,7 @@ void RE_AddRefEntityToScene( const refEntity_t *ent ) {
 		return;
 	}
 
-	/*if ( Q_isnan(ent->origin[0]) || Q_isnan(ent->origin[1]) || Q_isnan(ent->origin[2]) ) {
+	/*if ( std::isnan(ent->origin[0]) || std::isnan(ent->origin[1]) || std::isnan(ent->origin[2]) ) {
 		static bool firstTime = true;
 		if (firstTime) {
 			firstTime = false;

--- a/codemp/rd-vanilla/tr_shade_calc.cpp
+++ b/codemp/rd-vanilla/tr_shade_calc.cpp
@@ -806,8 +806,8 @@ void RB_CalcFogTexCoords( float *st ) {
 			}
 		}
 
-		st[0] = Q_isnan (s) ? 0.0f : s;
-		st[1] = Q_isnan (s) ? 0.0f : t;
+		st[0] = std::isnan (s) ? 0.0f : s;
+		st[1] = std::isnan (s) ? 0.0f : t;
 		st += 2;
 	}
 }

--- a/shared/qcommon/q_math.cpp
+++ b/shared/qcommon/q_math.cpp
@@ -24,10 +24,10 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 #include "qcommon/q_shared.h"
 #include "qcommon/q_math.h"
-#include <assert.h>
-#include <float.h>
-#include <math.h>
-#include <stdlib.h>
+#include <cassert>
+#include <cfloat>
+#include <cmath>
+#include <cstdlib>
 
 // DIRECTION ENCODING
 
@@ -356,7 +356,7 @@ float Q_rsqrt( float number )
 	y  = y * ( threehalfs - ( x2 * y * y ) );   // 1st iteration
 												//	y  = y * ( threehalfs - ( x2 * y * y ) );   // 2nd iteration, this can be removed
 
-	assert( !Q_isnan(y) );
+	assert( !std::isnan(y) );
 	return y;
 }
 
@@ -408,15 +408,6 @@ float Q_powf ( float x, int y )
 	for ( y--; y>0; y-- )
 		r *= x;
 	return r;
-}
-
-bool Q_isnan (float f)
-{
-#ifdef _MSC_VER
-	return (bool)(_isnan (f) != 0);
-#else
-	return (bool)(isnan (f) != 0);
-#endif
 }
 
 int Q_log2( int val )

--- a/shared/qcommon/q_math.h
+++ b/shared/qcommon/q_math.h
@@ -29,7 +29,7 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 // ======================================================================
 
 #include <cstdint>
-#include <math.h>
+#include <cmath>
 
 #include "qcommon/q_type.h"
 
@@ -176,7 +176,6 @@ float Q_rsqrt(float number);
 int Com_AbsClampi(int min, int max, int value);
 int Com_Clampi(int min, int max, int value);
 int Q_log2(int val);
-bool Q_isnan(float f);
 signed char ClampChar(int i);
 signed short ClampShort(int i);
 void AnglesSubtract(vec3_t v1, vec3_t v2, vec3_t v3);

--- a/shared/qcommon/q_platform.h
+++ b/shared/qcommon/q_platform.h
@@ -228,7 +228,12 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 #if defined (_MSC_VER)
 	#if _MSC_VER >= 1600
-		#include <stdint.h>
+		// needed for mp3 code still being in C
+		#if defined(__cplusplus)
+			#include <cstdint>
+		#else
+			#include <stdint.h>
+		#endif
 	#else
 		typedef signed __int64 int64_t;
 		typedef signed __int32 int32_t;
@@ -243,7 +248,12 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 	#if !defined(__STDC_LIMIT_MACROS)
 		#define __STDC_LIMIT_MACROS
 	#endif
-	#include <stdint.h>
+	// needed for mp3 code still being in C
+	#if defined(__cplusplus)
+		#include <cstdint>
+	#else
+		#include <stdint.h>
+	#endif
 #endif
 
 // catch missing defines in above blocks
@@ -265,7 +275,12 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 // endianness
 // Use compiler builtins where possible for maximum performance
-#include <stdint.h>
+// needed for mp3 code still being in C
+#if defined(__cplusplus)
+	#include <cstdint>
+#else
+	#include <stdint.h>
+#endif
 #if !defined(__clang__) && (defined(__GNUC__) || defined(__GNUG__)) \
             && ((__GNUC__ * 100 + __GNUC_MINOR__) >= 403)
 // gcc >= 4.3
@@ -287,7 +302,13 @@ static inline uint32_t LongSwap(uint32_t v)
 // MSVC
 
 // required for _byteswap_ushort/ulong
-#include <stdlib.h>
+// needed for mp3 code still being in C
+#if defined(__cplusplus)
+	#include <cstdlib>
+#else
+	#include <stdlib.h>
+#endif
+
 
 static uint16_t ShortSwap(uint16_t v)
 {

--- a/shared/qcommon/q_string.cpp
+++ b/shared/qcommon/q_string.cpp
@@ -1,14 +1,14 @@
 #include "qcommon/q_shared.h"
 #include "qcommon/q_string.h"
 
-#include <assert.h>
-#include <ctype.h>
-#include <errno.h>
-#include <math.h>
-#include <stddef.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+#include <cassert>
+#include <cctype>
+#include <cerrno>
+#include <cmath>
+#include <cstddef>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 
 #include "qcommon/q_color.h"
 

--- a/shared/sdl/sdl_sound.cpp
+++ b/shared/sdl/sdl_sound.cpp
@@ -20,8 +20,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 ===========================================================================
 */
 
-#include <stdlib.h>
-#include <stdio.h>
+#include <cstdlib>
+#include <cstdio>
 
 #include <SDL.h>
 

--- a/shared/sys/con_tty.cpp
+++ b/shared/sys/con_tty.cpp
@@ -27,7 +27,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include "sys/con_local.h"
 
 #include <unistd.h>
-#include <signal.h>
+#include <csignal>
 #include <termios.h>
 #include <fcntl.h>
 #include <sys/time.h>

--- a/shared/sys/snapvector.cpp
+++ b/shared/sys/snapvector.cpp
@@ -22,12 +22,12 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 ===========================================================================
 */
 
-#include <math.h>
+#include <cmath>
 #if _MSC_VER
-# include <float.h>
+# include <cfloat>
 # pragma fenv_access (on)
 #else
-# include <fenv.h>
+# include <cfenv>
 #endif
 
 #if _MSC_VER

--- a/shared/sys/sys_main.cpp
+++ b/shared/sys/sys_main.cpp
@@ -26,7 +26,7 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 #include <cstdio>
 #include <sys/stat.h>
 #define __STDC_FORMAT_MACROS
-#include <inttypes.h>
+#include <cinttypes>
 #include "qcommon/q_common.h"
 #include "qcommon/com_cvar.h"
 #include "qcommon/com_cvars.h"

--- a/shared/sys/sys_unix.cpp
+++ b/shared/sys/sys_unix.cpp
@@ -21,10 +21,10 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 */
 
 #include <dirent.h>
-#include <stdarg.h>
-#include <stdlib.h>
+#include <cstdarg>
+#include <cstdlib>
 #include <sys/time.h>
-#include <errno.h>
+#include <cerrno>
 #include <unistd.h>
 #include <fcntl.h>
 #include <sys/stat.h>
@@ -32,7 +32,7 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 #include <pwd.h>
 #include <libgen.h>
 #include <sched.h>
-#include <signal.h>
+#include <csignal>
 
 #include "qcommon/q_common.h"
 #include "qcommon/q_shared.h"

--- a/shared/sys/sys_unix.cpp
+++ b/shared/sys/sys_unix.cpp
@@ -461,8 +461,8 @@ char *Sys_DefaultHomePath(void)
 			Com_sprintf( homePath, sizeof( homePath ), "%s%c", p, PATH_SEP );
 			Q_strcat( homePath, sizeof( homePath ), "Library/Application Support/" );
 
-			if ( com_homepath && com_homepath->string[0] )
-				Q_strcat( homePath, sizeof( homePath ), com_homepath->string );
+			if ( fs_homepath && fs_homepath->string[0] )
+				Q_strcat( homePath, sizeof( homePath ), fs_homepath->string );
 			else
 				Q_strcat( homePath, sizeof( homePath ), HOMEPATH_NAME_MACOSX );
 		}


### PR DESCRIPTION
- Replace missing old C headers with their equivalent in C++ (<stdlib.h> become <cstdlib>, etc)
- Due to mp3 code still being in C, make it use old C header include (called from q_platform.h)
- Fix a problem in snd code when NULL was still used on an ALint type, since we now use nullptr this isn't compatible anymore, old C behavior with NULL was 0
- Replace all Q_isnan/_isnan with std::isnan
- Replace remaining com_homepath by fs_homepath
- ~Move define DEBUG_SABER_BOX from g_local.h to g_xcvar.h~